### PR TITLE
add work around for nested assets fingerprinting issue

### DIFF
--- a/lib/asset-rev.js
+++ b/lib/asset-rev.js
@@ -33,12 +33,24 @@ function AssetRev(inputTree, options) {
   var assetRewrite = UseRev(fingerprintTree, this);
 
   // second pass - fingerprints replaceable source code
-  this.exclude = exclude;
+  this.exclude = exclude.slice();
+  if (options.filesForThirdPass) {
+    this.exclude = this.exclude.concat(options.filesForThirdPass);
+  }
   this.onlyHash = this.replaceExtensions;
   var fingerprintTree2 = Fingerprint(assetRewrite, this);
   var assetRewrite2 = UseRev(fingerprintTree2, this);
 
-  return new FastbootManifestRewrite(assetRewrite2, this.assetMap);
+  // Some files may need to be hashed until the third
+  // pass since they contain references to other files that are fingerprinted
+  if (options.filesForThirdPass) {
+    this.exclude = exclude;
+    this.onlyHash = options.filesForThirdPass;
+    var fingerprintTree3 = Fingerprint(assetRewrite2, this);
+    var assetRewrite3 = UseRev(fingerprintTree3, this);
+  }
+
+  return new FastbootManifestRewrite(assetRewrite3 || assetRewrite2, this.assetMap);
 }
 
 module.exports = AssetRev;


### PR DESCRIPTION
adding another run of Fingerprint + UseRev on specific files will make sure that nested assets properly fingerprinted
